### PR TITLE
feat: support reading DOCKER_HOST from testcontainers props file

### DIFF
--- a/docker_test.go
+++ b/docker_test.go
@@ -1187,6 +1187,69 @@ func TestEntrypoint(t *testing.T) {
 	defer c.Terminate(ctx)
 }
 
+func TestGrepDockerhost(t *testing.T) {
+	tests := []struct {
+		content  string
+		expected string
+	}{
+		{
+			"docker.host = tcp://127.0.0.1:33293",
+			"tcp://127.0.0.1:33293",
+		},
+		{
+			"docker.host = tcp://127.0.0.1:33293",
+			"tcp://127.0.0.1:33293",
+		},
+		{
+			`docker.host = tcp://127.0.0.1:33293
+docker.host = tcp://127.0.0.1:4711
+`,
+			"tcp://127.0.0.1:33293",
+		},
+		{`docker.host = tcp://127.0.0.1:33293
+docker.host = tcp://127.0.0.1:4711
+docker.host = tcp://127.0.0.1:1234
+`,
+			"tcp://127.0.0.1:33293",
+		},
+		{
+			"",
+			"",
+		},
+		{
+			`foo = bar
+docker.host = tcp://127.0.0.1:1234
+		`,
+			"tcp://127.0.0.1:1234",
+		},
+		{
+			"docker.host=tcp://127.0.0.1:33293",
+			"tcp://127.0.0.1:33293",
+		},
+		{
+			`#docker.host=tcp://127.0.0.1:33293`,
+			"",
+		},
+		{
+			`#docker.host = tcp://127.0.0.1:33293
+docker.host = tcp://127.0.0.1:4711
+docker.host = tcp://127.0.0.1:1234`,
+			"tcp://127.0.0.1:4711",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			host := grepDockerhost(tt.content)
+
+			if host != tt.expected {
+				t.Errorf("'%s' is not equal '%s'", host, tt.expected)
+			}
+		})
+	}
+
+}
+
 func ExampleDockerProvider_CreateContainer() {
 	ctx := context.Background()
 	req := ContainerRequest{

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/testcontainers/testcontainers-go
 go 1.13
 
 require (
+	github.com/Flaque/filet v0.0.0-20201012163910-45f684403088 // indirect
 	github.com/Microsoft/hcsshim v0.8.16 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/docker/docker v20.10.9+incompatible

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZ
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/Flaque/filet v0.0.0-20201012163910-45f684403088 h1:PnnQln5IGbhLeJOi6hVs+lCeF+B1dRfFKPGXUAez0Ww=
+github.com/Flaque/filet v0.0.0-20201012163910-45f684403088/go.mod h1:TK+jB3mBs+8ZMWhU5BqZKnZWJ1MrLo8etNVg51ueTBo=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
@@ -485,6 +487,7 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
+github.com/spf13/afero v1.2.2 h1:5jhuqJyZCZf2JRofRvN/nIFgIWNzPa3/Vz8mYylgbWc=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=


### PR DESCRIPTION
## What does this PR do?
It adds support for retrieving the Docker host (remote or local) reading the DOCKER_HOST value from Testcontainers' default properties file (which is used at testcontainers-java for quite some time).

That file is located at `~/.testcontainers.properties)`.

## Why is it important?
There are two main reasons:

1. consistency across Testcontainers flavours
2. support running the containers ina remote Docker Host

## Follow-up concerns 
I've not tested this feature with Docker Compose yet (hopefully I can get some feedback from you all first)


