### PR TITLE
chore: display test summary on GH actions

### DIFF
--- a/.github/workflows/ci-podman.yml
+++ b/.github/workflows/ci-podman.yml
@@ -49,4 +49,10 @@ jobs:
         # many (maybe, all?) images used can only be build on Linux, they don't have Windows in their manifest, and
         # we can't put Windows Server in "Linux Mode" in Github actions
         # another, host mode is only available on Linux, and we have tests around that, do we skip them?
-        run: sudo go run gotest.tools/gotestsum --format short-verbose --rerun-fails=5 --packages="./..." -- -coverprofile=cover.txt
+        run: sudo go run gotest.tools/gotestsum --junitfile TEST-testcontainers-go.xml --format short-verbose --rerun-fails=5 --packages="./..." -- -coverprofile=cover.txt
+
+      - name: Test Summary
+        uses: test-summary/action@v1
+        with:
+          paths: "**/TEST-*.xml"
+        if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,13 @@ jobs:
         # we can't put Windows Server in "Linux Mode" in Github actions
         # another, host mode is only available on Linux, and we have tests around that, do we skip them?
         if: ${{ matrix.platform == 'ubuntu-latest' }}
-        run: go run gotest.tools/gotestsum --format short-verbose --rerun-fails=5 --packages="./..." -- -coverprofile=cover.txt
+        run: go run gotest.tools/gotestsum --junitfile TEST-testcontainers-go.xml --format short-verbose --rerun-fails=5 --packages="./..." -- -coverprofile=cover.txt
+
+      - name: Test Summary
+        uses: test-summary/action@v1
+        with:
+          paths: "**/TEST-*.xml"
+        if: always()
 
         # only report code coverage on linux
       - name: Upload coverage report


### PR DESCRIPTION
## What does this PR do?
It adds the `test-summary/action` GH action (https://github.com/test-summary/action) to both GH actions, which produces an easy-to-read summary of project's test data as part of the GitHub Actions CI/CD workflow.

## Why is it important?
This will help us understand at-a-glance the impact to the changes in our pull requests.
