### PR TITLE
chore: pin codecov's GH action to v3.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         # only report code coverage on linux
       - name: Upload coverage report
         if: ${{ matrix.platform == 'ubuntu-latest' }}
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378
         with:
           files: ./cover.txt
           name: testcontainers-go-${{ matrix.go-version }}


### PR DESCRIPTION
## What does this PR do?
It uses the hashed version of Codecov's GH action, pinning it to v3.1.0. See https://github.com/codecov/codecov-action/releases/tag/v3.1.0

## Why is it important?
Security concerns about using dynamic version of GH actions

## Related issues
- Closes #312
